### PR TITLE
Add a test to clarify double-colon behavior.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,6 +430,12 @@ mod tests {
     }
 
     #[test]
+    fn double_colons() {
+        assert_eq!(parse("Class::method").terms, &[Term::new(false, Some("Class"), ":method")]);
+        assert_eq!(parse("'Class::method'").terms, &[Term::new(false, None, "Class::method")]);
+    }
+
+    #[test]
     fn quoted_values() {
         assert_eq!(parse("key:'value'").terms, &[Term::new(false, Some("key"), "value")]);
         assert_eq!(parse("key:\"value with spaces\"").terms, &[Term::new(false, Some("key"), "value with spaces")]);


### PR DESCRIPTION
In https://github.com/staktrace/query-parser/issues/1 it was determined that special-handling for "Foo::Bar" identifiers was not appropriate; this adds a test that helps clarify that this behavior is understood and checked/enforced.